### PR TITLE
replace default int-types with safe fix length types in ZCodeHeader

### DIFF
--- a/code/TweeZcodeCompiler/main/ZCodeHeader.cpp
+++ b/code/TweeZcodeCompiler/main/ZCodeHeader.cpp
@@ -16,7 +16,7 @@ using namespace std;
 #define STANDARD_REVISION_MAIN 1 // revision number of supperted document, here
 #define STANDARD_REVISION_SUB 1  // 1.1 (STANDARD_REVISION_MAIN.STANDARD_REVISION_SUB)
 
-vector<bitset<8>>*ZCodeHeader::getHeaderBits() {
+vector<bitset<8>> *ZCodeHeader::getHeaderBits() {
     if (!fileLengthSet) {
         cout << "No file size specified!" << endl;
         throw;
@@ -44,7 +44,7 @@ vector<bitset<8>>*ZCodeHeader::getHeaderBits() {
     setShortVal(screenWidthUnits, headerBits);       // Hex 22 - 23
     setShortVal(screenHeightUnits, headerBits);      // Hex 24 - 25
     headerBits->push_back(fontWidthUnits);           // Hex 26
-    headerBits-> push_back(fontHeightUnits);         // Hex 27
+    headerBits->push_back(fontHeightUnits);         // Hex 27
     setShortVal(routinesOffset, headerBits);         // Hex 28 - 29
     setShortVal(staticStringsOffset, headerBits);    // Hex 2A - 2B
     headerBits->push_back(defBackgroundColor);       // Hex 2C
@@ -66,14 +66,14 @@ vector<bitset<8>>*ZCodeHeader::getHeaderBits() {
 /* helper method to calculate length and to
  * avoid not setting these values before calling getHeaderBits()
  * */
-void ZCodeHeader::setFileLength(unsigned int length, unsigned short checksum) {
-    int len = length / 8;
+void ZCodeHeader::setFileLength(uint64_t length, uint16_t checksum) {
+    uint64_t len = length / 8;
 
-    if (len > numeric_limits<unsigned short>::max()) {
+    if (len > numeric_limits<uint16_t>::max()) {
         cout << "File too large" << endl;
         throw;
     } else {
-        fileLength = len;
+        fileLength = (uint16_t) len;
         fileChecksum = checksum;
         fileLengthSet = true;
     }
@@ -82,14 +82,14 @@ void ZCodeHeader::setFileLength(unsigned int length, unsigned short checksum) {
 /* helper method to calculate routines offset and to
  * avoid not setting this value before calling getHeaderBits()
  * */
-void ZCodeHeader::setRoutinesOffset(unsigned int offset) {
-    int off = offset / 8;
+void ZCodeHeader::setRoutinesOffset(uint64_t offset) {
+    uint64_t off = offset / 8;
 
-    if (off > numeric_limits<unsigned short>::max()) {
+    if (off > numeric_limits<uint16_t>::max()) {
         cout << "Routine offset too large" << endl;
         throw;
     } else {
-        routinesOffset = off;
+        routinesOffset = (uint16_t) off;
         routinesOffsetSet = true;
     }
 }
@@ -97,14 +97,14 @@ void ZCodeHeader::setRoutinesOffset(unsigned int offset) {
 /* helper method to calculate static string offset and to
  * avoid not setting this value before calling getHeaderBits()
  * */
-void ZCodeHeader::setStaticStringsOffset(unsigned int offset) {
-    int off = offset / 8;
+void ZCodeHeader::setStaticStringsOffset(uint64_t offset) {
+    uint64_t off = offset / 8;
 
-    if (off > numeric_limits<unsigned short>::max()) {
+    if (off > numeric_limits<uint16_t>::max()) {
         cout << "Routine offset too large" << endl;
         throw;
     } else {
-        staticStringsOffset = off;
+        staticStringsOffset = (uint16_t) off;
         staticStringsOffsetSet = true;
     }
 }
@@ -160,8 +160,8 @@ void ZCodeHeader::setFlags2(std::vector<std::bitset<8>> *header) {
 }
 
 // splits short value up to 2 bytes and pushes them into the headerBits
-void ZCodeHeader::setShortVal(unsigned short val, vector<bitset<8>> *header) {
-    bitset<16> shortVal (val);
+void ZCodeHeader::setShortVal(uint16_t val, vector<bitset<8>> *header) {
+    bitset<16> shortVal(val);
     bitset<8> firstHalf, secondHalf;
 
     for (size_t i = 0; i < 8; i++) {
@@ -169,7 +169,7 @@ void ZCodeHeader::setShortVal(unsigned short val, vector<bitset<8>> *header) {
     }
 
     for (size_t i = 8; i < 16; i++) {
-        firstHalf.set(i-8, shortVal[i]);
+        firstHalf.set(i - 8, shortVal[i]);
     }
 
     header->push_back(firstHalf);

--- a/code/TweeZcodeCompiler/main/ZCodeHeader.h
+++ b/code/TweeZcodeCompiler/main/ZCodeHeader.h
@@ -7,16 +7,17 @@
 
 #include <bitset>
 #include <vector>
+#include <cstdint>
 
 class ZCodeHeader {
 
 private:
     std::vector<std::bitset<8>> *headerBits;
 
-    unsigned short fileLength;
-    unsigned short fileChecksum;
-    unsigned short routinesOffset;
-    unsigned short staticStringsOffset;
+    uint16_t fileLength;
+    uint16_t fileChecksum;
+    uint16_t routinesOffset;
+    uint16_t staticStringsOffset;
 
     // flags show if headerBits is initialized
     bool fileLengthSet = false;
@@ -25,11 +26,13 @@ private:
 
     // set special parts of headerBits
     void setFlags1(std::vector<std::bitset<8>> *header);
+
     void setAddresses(std::vector<std::bitset<8>> *header);
+
     void setFlags2(std::vector<std::bitset<8>> *header);
 
     // split short values upt to 2 bytes
-    void setShortVal(unsigned short val, std::vector<std::bitset<8>> *header);
+    void setShortVal(uint16_t val, std::vector<std::bitset<8>> *header);
 
 public:
     //HEADER POSITIONS
@@ -45,13 +48,13 @@ public:
     bool timedKeyboardAvail = false;
 
     // byte addresses
-    unsigned short baseOfHighMem;        // 2 bytes
-    unsigned char initValOfPC;           // initial value of program counter
-    unsigned char packedAddressOfMain;   // packed address of initial "main" routine
-    unsigned short locOfDict;            // location of dictionary
-    unsigned short locOfObjTable;        // location of object table
-    unsigned short locOfGlobVarTable;    // location of global variable table
-    unsigned short baseOfStatMem;        // base of static memory
+    uint16_t baseOfHighMem;        // 2 bytes
+    uint8_t initValOfPC;           // initial value of program counter
+    uint8_t packedAddressOfMain;   // packed address of initial "main" routine
+    uint16_t locOfDict;            // location of dictionary
+    uint16_t locOfObjTable;        // location of object table
+    uint16_t locOfGlobVarTable;    // location of global variable table
+    uint16_t baseOfStatMem;        // base of static memory
 
     // Flags 2 in Hex position 10 to 17
     bool transcripting = false;
@@ -64,29 +67,31 @@ public:
     bool useSoundEffects = false;
     bool useMenus = false;
 
-    unsigned short locOfAbbrTable;              // location of abbreviation Table (byte address)
+    uint16_t locOfAbbrTable;              // location of abbreviation Table (byte address)
 
-    unsigned char screenHeight = 255;           // 255 = infinite
-    unsigned char screenWidthCharacters;
-    unsigned short screenWidthUnits;
-    unsigned short screenHeightUnits;
-    unsigned char fontHeightUnits;
-    unsigned char fontWidthUnits;
+    uint8_t screenHeight = 255;           // 255 = infinite
+    uint8_t screenWidthCharacters;
+    uint16_t screenWidthUnits;
+    uint16_t screenHeightUnits;
+    uint8_t fontHeightUnits;
+    uint8_t fontWidthUnits;
 
-    unsigned char defBackgroundColor;
-    unsigned char defForegroundColor;
-    unsigned char addressOfCharTable;               // address of terminating characters table (bytes)
-    unsigned short totalWidthInPixels;              // total width in pixels of text sent to output stream 3
-    unsigned short alphabetTableAddress = 0;        // Alphabet table address (bytes), 0 for default
-    unsigned short headerExtensionTableAddress = 0;
+    uint8_t defBackgroundColor;
+    uint8_t defForegroundColor;
+    uint8_t addressOfCharTable;               // address of terminating characters table (bytes)
+    uint16_t totalWidthInPixels;              // total width in pixels of text sent to output stream 3
+    uint16_t alphabetTableAddress = 0;        // Alphabet table address (bytes), 0 for default
+    uint16_t headerExtensionTableAddress = 0;
 
     // helper methods - needed to be invoked before getHeaderBits()
-    void setFileLength(unsigned int length, unsigned short checksum);
-    void setRoutinesOffset(unsigned int offset);
-    void setStaticStringsOffset(unsigned int offset);
+    void setFileLength(uint64_t length, uint16_t checksum);
+
+    void setRoutinesOffset(uint64_t offset);
+
+    void setStaticStringsOffset(uint64_t offset);
 
     // get complete headerBits as vector<bitset>
-    std::vector<std::bitset<8>>*getHeaderBits();
+    std::vector<std::bitset<8>> *getHeaderBits();
 
     ~ZCodeHeader() {
         delete headerBits;


### PR DESCRIPTION
#23: replaced unsigned char, unsigned short, unsigned int with uint8_t, uint16_t, uint64_t form cstdint.h
