### PR TITLE
added stacktrace utilitiy function

### DIFF
--- a/code/TweeZcodeCompiler/main/main.cpp
+++ b/code/TweeZcodeCompiler/main/main.cpp
@@ -1,8 +1,16 @@
 #include <iostream>
+#include "stacktrace.h"
 
 #include "SimpleCompilerPipeline.h"
 
+void handler()
+{
+    print_stacktrace();
+}
+
 int main(int argc, char *argv[]) {
+    std::set_terminate(handler);
+
     // TODO: parse args properly (GNU getopt?)
     if (argc < 2) return 1;
     std::string inputFile = argv[argc - 1];

--- a/code/TweeZcodeCompiler/main/stacktrace.h
+++ b/code/TweeZcodeCompiler/main/stacktrace.h
@@ -1,0 +1,170 @@
+// stacktrace.h (c) 2008, Timo Bingmann from http://idlebox.net/
+// published under the WTFPL v2.0
+
+#ifndef _STACKTRACE_H_
+#define _STACKTRACE_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <execinfo.h>
+#include <cxxabi.h>
+
+/** Print a demangled stack backtrace of the caller function to FILE* out. */
+static inline void print_stacktrace(FILE *out = stderr, unsigned int max_frames = 63)
+{
+    fprintf(out, "stack trace:\n");
+
+    // storage array for stack trace address data
+    void* addrlist[max_frames+1];
+
+    // retrieve current stack addresses
+    int addrlen = backtrace(addrlist, static_cast<int>(sizeof(addrlist) / sizeof(void*)));
+
+    if (addrlen == 0)
+    {
+        fprintf(out, "  <empty, possibly corrupt>\n");
+        return;
+    }
+
+    // resolve addresses into strings containing "filename(function+address)",
+    // this array must be free()-ed
+    char** symbollist = backtrace_symbols(addrlist, addrlen);
+
+    // allocate string which will be filled with the demangled function name
+    size_t funcnamesize = 256;
+    char* funcname = (char*)malloc(funcnamesize);
+
+    // iterate over the returned symbol lines. skip the first, it is the
+    // address of this function.
+    for (int i = 1; i < addrlen; i++)
+    {
+        char *begin_name = 0, *end_name = 0, *begin_offset = 0, *end_offset = 0;
+
+        // find parentheses and +address offset surrounding the mangled name:
+        // ./module(function+0x15c) [0x8048a6d]
+        for (char *p = symbollist[i]; *p; ++p)
+        {
+            if (*p == '(')
+                begin_name = p;
+            else if (*p == '+')
+                begin_offset = p;
+            else if (*p == ')' && begin_offset)
+            {
+                end_offset = p;
+                break;
+            }
+        }
+
+        // BCH 24 Dec 2014: backtrace_symbols() on OS X seems to return strings in a different, non-standard format.
+        // Added this code in an attempt to parse that format.  No doubt it could be done more cleanly.  :->
+        if (!(begin_name && begin_offset && end_offset
+              && begin_name < begin_offset))
+        {
+            enum class ParseState {
+                kInWhitespace1 = 1,
+                kInLineNumber,
+                kInWhitespace2,
+                kInPackageName,
+                kInWhitespace3,
+                kInAddress,
+                kInWhitespace4,
+                kInFunction,
+                kInWhitespace5,
+                kInPlus,
+                kInWhitespace6,
+                kInOffset,
+                kInOverrun
+            };
+            ParseState parse_state = ParseState::kInWhitespace1;
+            char *p;
+
+            for (p = symbollist[i]; *p; ++p)
+            {
+                switch (parse_state)
+                {
+                    case ParseState::kInWhitespace1:	if (!isspace(*p)) parse_state = ParseState::kInLineNumber;	break;
+                    case ParseState::kInLineNumber:		if (isspace(*p)) parse_state = ParseState::kInWhitespace2;	break;
+                    case ParseState::kInWhitespace2:	if (!isspace(*p)) parse_state = ParseState::kInPackageName;	break;
+                    case ParseState::kInPackageName:	if (isspace(*p)) parse_state = ParseState::kInWhitespace3;	break;
+                    case ParseState::kInWhitespace3:	if (!isspace(*p)) parse_state = ParseState::kInAddress;		break;
+                    case ParseState::kInAddress:		if (isspace(*p)) parse_state = ParseState::kInWhitespace4;	break;
+                    case ParseState::kInWhitespace4:
+                        if (!isspace(*p))
+                        {
+                            parse_state = ParseState::kInFunction;
+                            begin_name = p - 1;
+                        }
+                        break;
+                    case ParseState::kInFunction:
+                        if (isspace(*p))
+                        {
+                            parse_state = ParseState::kInWhitespace5;
+                            end_name = p;
+                        }
+                        break;
+                    case ParseState::kInWhitespace5:	if (!isspace(*p)) parse_state = ParseState::kInPlus;		break;
+                    case ParseState::kInPlus:			if (isspace(*p)) parse_state = ParseState::kInWhitespace6;	break;
+                    case ParseState::kInWhitespace6:
+                        if (!isspace(*p))
+                        {
+                            parse_state = ParseState::kInOffset;
+                            begin_offset = p - 1;
+                        }
+                        break;
+                    case ParseState::kInOffset:
+                        if (isspace(*p))
+                        {
+                            parse_state = ParseState::kInOverrun;
+                            end_offset = p;
+                        }
+                        break;
+                    case ParseState::kInOverrun:
+                        break;
+                }
+            }
+
+            if (parse_state == ParseState::kInOffset && !end_offset)
+                end_offset = p;
+        }
+
+        if (begin_name && begin_offset && end_offset
+            && begin_name < begin_offset)
+        {
+            *begin_name++ = '\0';
+            if (end_name)
+                *end_name = '\0';
+            *begin_offset++ = '\0';
+            *end_offset = '\0';
+
+            // mangled name is now in [begin_name, begin_offset) and caller
+            // offset in [begin_offset, end_offset). now apply __cxa_demangle():
+
+            int status;
+            char *ret = abi::__cxa_demangle(begin_name, funcname, &funcnamesize, &status);
+
+            if (status == 0)
+            {
+                funcname = ret; // use possibly realloc()-ed string
+                fprintf(out, "  %s : %s + %s\n", symbollist[i], funcname, begin_offset);
+            }
+            else
+            {
+                // demangling failed. Output function name as a C function with
+                // no arguments.
+                fprintf(out, "  %s : %s() + %s\n", symbollist[i], begin_name, begin_offset);
+            }
+        }
+        else
+        {
+            // couldn't parse the line? print the whole line.
+            fprintf(out, "URF:  %s\n", symbollist[i]);
+        }
+    }
+
+    free(funcname);
+    free(symbollist);
+
+    fflush(out);
+}
+
+#endif // _STACKTRACE_H_


### PR DESCRIPTION
Prints a nicely formatted stacktrace in case of an exception (and maybe crash? not totally sure).

I've only tested this on Mac OS X so far, please check if this works in Linux.
