### PR TITLE
add MIT sample license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2015 Manuel Polzhofer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
The MIT license is a permissive license which allows us to redistribute the software either in binary form or in source-code (no copyleft). I think it's suitable, as the repository has been set to private for now (which might turn out to be a problem if we decided to use the GPL instead).

The only restriction any user of the software faces, is that a copy of the license has to be included with any redistributed form of our software. Since the MIT license itself is not copyrighted we could also simply remove this restriction.

I chose Manuel Polzhofer (@manuelpolzhofer) as the copyright holder, simply because he's the one who owns this repository. I anyone wants to include all of us as copyright holders, you're welcome to find out how this can be done in a simple and short manner.
